### PR TITLE
Fix float usage

### DIFF
--- a/hbase-region.py
+++ b/hbase-region.py
@@ -130,7 +130,7 @@ class HBaseRegionCollector(diamond.collector.Collector):
                     continue
                 func = self.BEANS_MAP[bean_name]
                 for path, value in func(bean):
-                    self.publish(path, value)
+                    self.publish(path, value, precision=2)
         except URLError:
             pass
 


### PR DESCRIPTION
All metrics are float, so we can always specify the precision.